### PR TITLE
fixed celery demo link

### DIFF
--- a/celery-presentation/README.md
+++ b/celery-presentation/README.md
@@ -2,4 +2,4 @@
 
 26 Mayıs 2012 tarihinde Fatih Erikli tarafından sunulmuştur.
 
-Demo: https://github.com/pyist/demos/tree/master/celery-demo
+Demo: [Celery Demo](https://github.com/pyistanbul/demos/tree/master/celery-demo)


### PR DESCRIPTION
[Celery Sunumu](https://github.com/pyistanbul/presentations/tree/master/celery-presentation)nun demo linki yanlislikla pyist'a olarak verilmis.

Duzeltildi. :)